### PR TITLE
Fix LoCoMo eval isolation and prompt rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ locomo10.json  ->  list of samples
 
 ### `ingest` - Load conversations into openclaw
 
-Sends conversation sessions to openclaw to build up memory/context. All sessions within a sample share one user UUID so context accumulates.
+Sends conversation sessions to openclaw to build up memory/context. All sessions within a sample share one user key so context accumulates. By default, each LoCoMo sample uses an isolated key like `eval-conv-26`; pass `--user` to override it.
 
 ```bash
 # Ingest specific sample, sessions 1-4
@@ -62,11 +62,11 @@ uv run python eval.py ingest ./locomo10.json --sample 0 --sessions 1-4 --output 
 uv run python eval.py ingest example.txt --output output.txt
 ```
 
-Ingest prints the user UUID for each sample:
+Ingest prints the user key for each sample:
 
 ```
 === Sample conv-26 ===
-    user: f5d94f68-24aa-4bcc-a667-9ab11bf5edab
+    user: eval-conv-26
     4 session(s) to ingest
 ```
 
@@ -87,14 +87,14 @@ https://example.com/image.jpg: a photo of a dog walking past a wall
 
 ### `qa` - Run QA evaluation
 
-Sends QA questions to openclaw and records responses alongside expected answers. **No ingestion** - requires `--user` UUID from a prior ingest run.
+Sends QA questions to openclaw and records responses alongside expected answers. **No ingestion** - uses the same per-sample default user key as ingest, or pass `--user` if ingest used an explicit override.
 
 ```bash
-# Run all QAs for sample 0 using user from ingest
-uv run python eval.py qa ./locomo10.json --sample 0 --user f5d94f68-... --output qa_results.txt
+# Run all QAs for sample 0
+uv run python eval.py qa ./locomo10.json --sample 0 --output qa_results.txt
 
 # Run first 10 QAs only
-uv run python eval.py qa ./locomo10.json --sample 0 --user f5d94f68-... --count 10 --output qa_results.txt
+uv run python eval.py qa ./locomo10.json --sample 0 --count 10 --output qa_results.txt
 ```
 
 Output format:
@@ -110,11 +110,11 @@ Output format:
 ## Typical Workflow
 
 ```bash
-# Step 1: ingest conversations (note the user UUID printed)
+# Step 1: ingest conversations
 uv run python eval.py ingest ./locomo10.json --sample 0 --sessions 1-4
 
-# Step 2: run QA using that user UUID
-uv run python eval.py qa ./locomo10.json --sample 0 --user <UUID> --output qa_results.txt
+# Step 2: run QA using the same default sample user key
+uv run python eval.py qa ./locomo10.json --sample 0 --output qa_results.txt
 ```
 
 ## CLI Options
@@ -129,5 +129,5 @@ uv run python eval.py qa ./locomo10.json --sample 0 --user <UUID> --output qa_re
 | `--sample` | all | LoCoMo: sample index (0-based) |
 | `--sessions` | all | Ingest: session range, e.g. `1-4` or `3` |
 | `--tail` | `[]` | Ingest: tail message appended per session |
-| `--user` | none | QA: user UUID from a prior ingest run (required) |
+| `--user` | per-sample key | Override OpenClaw user key for ingest or QA |
 | `--count` | all | QA: number of questions to run |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Caroline: Hey Mel! Good to see you!
 Melanie: Hey Caroline! What's up?
 
 Caroline: The transgender stories were so inspiring!
-https://example.com/image.jpg: a photo of a dog walking past a wall
+[shared image: a photo of a dog walking past a wall]
 
 []
 ```

--- a/eval.py
+++ b/eval.py
@@ -73,23 +73,16 @@ def format_locomo_message(msg: dict) -> str:
 
     Output format:
         Speaker: text here
-        image_url: caption
+        [shared image: caption]
     """
     speaker = msg.get("speaker", "unknown")
     text = msg.get("text", "")
     line = f"{speaker}: {text}"
 
-    img_urls = msg.get("img_url", [])
-    if isinstance(img_urls, str):
-        img_urls = [img_urls]
     blip = msg.get("blip_caption", "")
 
-    if img_urls:
-        for url in img_urls:
-            caption = f": {blip}" if blip else ""
-            line += f"\n{url}{caption}"
-    elif blip:
-        line += f"\n({blip})"
+    if blip:
+        line += f"\n[shared image: {blip}]"
 
     return line
 

--- a/eval.py
+++ b/eval.py
@@ -110,6 +110,11 @@ def load_locomo_data(
     return data
 
 
+def default_sample_user(sample_id: str) -> str:
+    """Return the default isolated OpenClaw user key for one LoCoMo sample."""
+    return f"eval-{sample_id}"
+
+
 def build_session_messages(
     item: dict,
     session_range: tuple[int, int] | None = None,
@@ -275,7 +280,7 @@ def run_ingest(
 
         for item in samples:
             sample_id = item["sample_id"]
-            user_key = args.user or "eval-1"
+            user_key = args.user or default_sample_user(sample_id)
             sessions = build_session_messages(item, session_range, tail=args.tail)
 
             print(f"\n=== Sample {sample_id} ===", file=sys.stderr)
@@ -405,7 +410,7 @@ async def run_sample_qa(
 ) -> tuple[list[dict], dict]:
     """Process QA for a single sample. Returns (records, sample_usage)."""
     sample_id = item["sample_id"]
-    user_key = args.user or f"eval-{sample_idx}"
+    user_key = args.user or default_sample_user(sample_id)
     qas = [q for q in item.get("qa", []) if str(q.get("category", "")) != "5"]
     if args.count is not None:
         qas = qas[:args.count]
@@ -484,7 +489,7 @@ def run_qa(
 
     samples = load_locomo_data(args.input, args.sample)
     parallel = min(args.parallel, 10)
-    print(f"    user: {args.user or 'eval-{sample_idx}'}", file=sys.stderr)
+    print(f"    user: {args.user or 'per-sample default'}", file=sys.stderr)
     print(f"    parallel: {parallel}", file=sys.stderr)
 
     async def _run():
@@ -572,7 +577,7 @@ def main():
     parser.add_argument(
         "--user",
         default=None,
-        help="QA mode: user UUID from a prior ingest run to target.",
+        help="Override OpenClaw user key for ingest or QA. Default: per-sample key.",
     )
     parser.add_argument(
         "-p", "--parallel",

--- a/tests/test_eval_user_keys.py
+++ b/tests/test_eval_user_keys.py
@@ -30,6 +30,39 @@ def locomo_sample(sample_id: str) -> dict:
 
 
 class EvalUserKeyTests(unittest.TestCase):
+    def test_locomo_message_uses_caption_without_url_or_query(self):
+        formatted = eval_module.format_locomo_message(
+            {
+                "speaker": "Caroline",
+                "text": "The transgender stories were so inspiring!",
+                "img_url": ["https://i.redd.it/l7hozpetnhlb1.jpg"],
+                "blip_caption": "a photo of a dog walking past a wall with a painting of a woman",
+                "query": "transgender stories poster",
+            }
+        )
+
+        self.assertEqual(
+            formatted,
+            "Caroline: The transgender stories were so inspiring!\n"
+            "[shared image: a photo of a dog walking past a wall with a painting of a woman]",
+        )
+        self.assertNotIn("https://", formatted)
+        self.assertNotIn("transgender stories poster", formatted)
+
+    def test_locomo_message_keeps_caption_when_url_is_absent(self):
+        formatted = eval_module.format_locomo_message(
+            {
+                "speaker": "Melanie",
+                "text": "Look at this.",
+                "blip_caption": "a painting on a brick wall",
+            }
+        )
+
+        self.assertEqual(
+            formatted,
+            "Melanie: Look at this.\n[shared image: a painting on a brick wall]",
+        )
+
     def test_json_ingest_defaults_to_one_user_per_sample(self):
         args = argparse.Namespace(
             input="locomo.json",

--- a/tests/test_eval_user_keys.py
+++ b/tests/test_eval_user_keys.py
@@ -1,0 +1,98 @@
+import argparse
+import asyncio
+import importlib
+import unittest
+from unittest import mock
+
+
+eval_module = importlib.import_module("eval")
+
+
+def locomo_sample(sample_id: str) -> dict:
+    return {
+        "sample_id": sample_id,
+        "conversation": {
+            "speaker_a": "Alice",
+            "speaker_b": "Bob",
+            "session_1": [
+                {"speaker": "Alice", "text": "hello"},
+            ],
+        },
+        "qa": [
+            {
+                "question": "What did Alice say?",
+                "answer": "hello",
+                "category": 1,
+                "evidence": ["D1:1"],
+            }
+        ],
+    }
+
+
+class EvalUserKeyTests(unittest.TestCase):
+    def test_json_ingest_defaults_to_one_user_per_sample(self):
+        args = argparse.Namespace(
+            input="locomo.json",
+            sample=None,
+            sessions=None,
+            tail="[]",
+            user=None,
+            viking=False,
+            base_url="http://127.0.0.1:18789",
+            token="token",
+            output=None,
+        )
+        sent_users = []
+
+        def fake_send_message(_base_url, _token, user, _message):
+            sent_users.append(user)
+            return "ok", {}
+
+        with (
+            mock.patch.object(
+                eval_module,
+                "load_locomo_data",
+                return_value=[locomo_sample("conv-26"), locomo_sample("conv-30")],
+            ),
+            mock.patch.object(eval_module, "send_message", side_effect=fake_send_message),
+            mock.patch.object(eval_module, "get_session_id", return_value=None),
+            mock.patch.object(eval_module, "reset_session"),
+        ):
+            eval_module.run_ingest(args)
+
+        self.assertEqual(sent_users, ["eval-conv-26", "eval-conv-30"])
+
+    def test_qa_default_user_matches_ingest_default(self):
+        args = argparse.Namespace(
+            user=None,
+            count=None,
+            output=None,
+            base_url="http://127.0.0.1:18789",
+            token="token",
+        )
+        sent_users = []
+
+        def fake_send_message_with_retry(_base_url, _token, user, _message):
+            sent_users.append(user)
+            return "hello", {}
+
+        async def run_test():
+            with (
+                mock.patch.object(
+                    eval_module,
+                    "send_message_with_retry",
+                    side_effect=fake_send_message_with_retry,
+                ),
+                mock.patch.object(eval_module, "get_session_id", return_value=None),
+                mock.patch.object(eval_module, "reset_session"),
+            ):
+                await eval_module.run_sample_qa(
+                    locomo_sample("conv-26"),
+                    1,
+                    args,
+                    asyncio.Semaphore(1),
+                )
+
+        asyncio.run(run_test())
+
+        self.assertEqual(sent_users, ["eval-conv-26"])


### PR DESCRIPTION
## Summary
- isolate LoCoMo ingest/QA defaults to one OpenClaw user key per sample
- render LoCoMo shared images as BLIP caption text only, without injecting raw image URLs
- document the caption-only chat reconstruction format

## Verification
- `uv run python -m unittest discover -s tests`
- `python -m py_compile eval.py`
